### PR TITLE
Ensures rbenv PATH is set correctly for user install.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,6 @@
   sudo: true
   when:
     - ansible_os_family != 'OpenBSD'
-    - rbenv.env == "system"
   tags:
     - rbenv
 


### PR DESCRIPTION
`rbenv.sh.j2` file has a system-wide and user setup but it wasn't included for a user install resulting in `rbenv: command not found` error.

Tested on CentOS 7.

I'd rather add some tests too but I have no idea how to do that easily.