### PR TITLE
Fixes system rbenv ruby install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,7 +144,7 @@
   shell: bash -lc "rbenv install {{ rbenv.ruby_version }}"
   when:
     - rbenv.env == "system"
-    - ruby_installed.rc == 0
+    - ruby_installed.rc != 0
   tags:
     - rbenv
 
@@ -152,7 +152,7 @@
   shell: bash -lc "rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
   when:
     - rbenv.env == "system"
-    - ruby_installed.rc == 0
+    - ruby_installed.rc != 0
   tags:
     - rbenv
 


### PR DESCRIPTION
Fixes regression introduced in #20

System rbenv wasn’t installing Ruby when version not found. More on
https://github.com/zzet/ansible-rbenv-role/pull/20#commitcomment-9223104

I've tested this successfully, locally. 