### PR TITLE
update ruby-build to v20141225 which ruby-2.2.0 stable included

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ rbenv_repo: "git://github.com/sstephenson/rbenv.git"
 
 rbenv_plugins:
   - { name: "rbenv-vars",         repo: "git://github.com/sstephenson/rbenv-vars.git",         version: "v1.2.0" }
-  - { name: "ruby-build",         repo: "git://github.com/sstephenson/ruby-build.git",         version: "v20141113" }
+  - { name: "ruby-build",         repo: "git://github.com/sstephenson/ruby-build.git",         version: "v20141225" }
   - { name: "rbenv-default-gems", repo: "git://github.com/sstephenson/rbenv-default-gems.git", version: "v1.0.0" }
   - { name: "rbenv-installer",    repo: "git://github.com/fesplugas/rbenv-installer.git",      version: "22cc96aa45d06faca5958b1aa1688596198407a3" }
   - { name: "rbenv-update",       repo: "git://github.com/rkh/rbenv-update.git",               version: "f0ff6e3264c45fdf2a8064205db6c8b3a707894e" }

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -7,6 +7,7 @@
     - libyaml-devel
     - readline-devel
     - zlib-devel
+    - libffi-devel
     - git
   sudo: true
   tags:


### PR DESCRIPTION
ruby 2.2.0 released and ruby-build had release v20141225.
This pr updated ruby-build to newest version and user can install ruby 2.2.0.