### PR TITLE
Fix duplicate task names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,7 +148,7 @@
   tags:
     - rbenv
 
-- name: install ruby {{ rbenv.ruby_version }} for system
+- name: set ruby {{ rbenv.ruby_version }} for system
   shell: bash -lc "rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
   when:
     - rbenv.env == "system"
@@ -179,7 +179,7 @@
   tags:
     - rbenv
 
-- name: install ruby {{ rbenv.ruby_version }} for select users
+- name: set ruby {{ rbenv.ruby_version }} for select users
   shell: $SHELL -lc "rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
   sudo: true
   sudo_user: "{{ item[1] }}"


### PR DESCRIPTION
A couple of the tasks had duplicate names, and didn't accurately describe what they were doing. Hopefully this makes it a bit clearer what is actually being done within said tasks.