### PR TITLE
Add libffi-dev on apt environment for ruby 2.2.0

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -10,6 +10,7 @@
     - build-essential
     - git
     - libcurl4-openssl-dev
+    - libffi-dev
     - libreadline-dev
     - libssl-dev
     - libxml2-dev


### PR DESCRIPTION
In Ruby 2.2.0 depends on `libffi`.
But not include this on apt environment.
