### PR TITLE
Don't skip ruby version checking in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -136,6 +136,7 @@
   register: ruby_installed
   changed_when: false
   ignore_errors: yes
+  always_run: yes
   when: rbenv.env == "system"
   tags:
     - rbenv
@@ -163,7 +164,9 @@
   with_items: rbenv_users
   when: not "system" == "{{ rbenv.env }}"
   register: ruby_installed
+  changed_when: false
   ignore_errors: yes
+  always_run: yes
   tags:
     - rbenv
 


### PR DESCRIPTION
Hi, this fixes a crash when executing this role in check mode:

```
TASK: [rbenv | install ruby {{ rbenv.ruby_version }} for select users] ********
fatal: [...] => error while evaluating conditional: (not "system" == "user") and (item[0].rc != 0)
FATAL: all hosts have already failed -- aborting
```
 This fails because the previous task `check ruby {{ rbenv.ruby_version }} installed for select users` was skipped, which means there is no value for item[0].rc in the task that fails.

Thank you veru much for this role, it's been immensely useful to us.