### PR TITLE
Git should use 'force' flag set to true to override local changes in rbenv or plugins repos

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
     dest={{ rbenv_root }}
     version={{ rbenv.version }}
     accept_hostkey=true
+    force=yes
   when: rbenv.env == "system"
   tags:
     - rbenv
@@ -34,6 +35,7 @@
     dest={{ rbenv_root }}/plugins/{{ item.name }}
     version={{ item.version }}
     accept_hostkey=true
+    force=yes
   with_items: rbenv_plugins
   when: rbenv.env == "system"
   tags:
@@ -45,6 +47,7 @@
     dest={{ rbenv_root }}
     version={{ rbenv.version }}
     accept_hostkey=true
+    force=yes
   with_items: rbenv_users
   sudo: true
   sudo_user: "{{ item }}"
@@ -69,6 +72,7 @@
     dest={{ rbenv_root }}/plugins/{{ item[1].name }}
     version={{ item[1].version }}
     accept_hostkey=true
+    force=yes
   with_nested:
     - rbenv_users
     - rbenv_plugins


### PR DESCRIPTION
Ansible 1.9 ( https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#19-dancing-in-the-street---mar-25-2015 ) changed  'force' flag for source control modules from 'true' to 'false' by default. This commit restores previous behavior and force check-out rbenv repo and plugins.