### PR TITLE
Added async to the ruby install task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,6 +179,8 @@
     - rbenv_users
   when: (not "system" == "{{ rbenv.env }}") and (item[0].rc != 0)
   ignore_errors: true
+  async: 900
+  poll: 30
   tags:
     - rbenv
 


### PR DESCRIPTION
Without asynchronous mode on virtual machines with weak cpu power this task never be ended. Ansible have timeout for task executing.