### PR TITLE
ruby-build v20151230 (ruby 2.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Default variables are:
           version: "v1.2.0" }
 
       - { name: "ruby-build",
-          repo: "https://github.com/sstephenson/ruby-build.git",
-          version: "v20151028" }
+          repo: "https://github.com/rbenv/ruby-build.git",
+          version: "v20151230" }
 
       - { name: "rbenv-default-gems",
           repo: "https://github.com/sstephenson/rbenv-default-gems.git",

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ rbenv_repo: "https://github.com/sstephenson/rbenv.git"
 
 rbenv_plugins:
   - { name: "rbenv-vars",         repo: "https://github.com/sstephenson/rbenv-vars.git",         version: "v1.2.0" }
-  - { name: "ruby-build",         repo: "https://github.com/sstephenson/ruby-build.git",         version: "v20151028" }
+  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",               version: "v20151230" }
   - { name: "rbenv-default-gems", repo: "https://github.com/sstephenson/rbenv-default-gems.git", version: "v1.0.0" }
   - { name: "rbenv-installer",    repo: "https://github.com/fesplugas/rbenv-installer.git",      version: "22cc96aa45d06faca5958b1aa1688596198407a3" }
   - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",               version: "bf757453498337807a46e24074d29173f1a8abec" }


### PR DESCRIPTION
rbenv is now its own org on github (with several plugins being part thereof). this patch updates the repo url (a redirect occurs, though) and ruby-build to v20151230.