### PR TITLE
Update rbenv-default-gems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,12 +8,12 @@ rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
 rbenv_plugins:
   - { name: "rbenv-vars",         repo: "https://github.com/rbenv/rbenv-vars.git",         version: "v1.2.0" }
-  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",               version: "v20151230" }
-  - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "v1.0.0" }
-  - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",      version: "bc21e7055dcc8f5f9bc66ce0c78cc9ae0c28cd7a" }
-  - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",               version: "1961fa180280bb50b64cbbffe6a5df7cf70f5e50" }
-  - { name: "rbenv-whatis",       repo: "https://github.com/rkh/rbenv-whatis.git",               version: "v1.0.0" }
-  - { name: "rbenv-use",          repo: "https://github.com/rkh/rbenv-use.git",                  version: "v1.0.0" }
+  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "v20151230" }
+  - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "ead67889c91c53ad967f85f5a89d986fdb98f6fb" }
+  - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "bc21e7055dcc8f5f9bc66ce0c78cc9ae0c28cd7a" }
+  - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "1961fa180280bb50b64cbbffe6a5df7cf70f5e50" }
+  - { name: "rbenv-whatis",       repo: "https://github.com/rkh/rbenv-whatis.git",         version: "v1.0.0" }
+  - { name: "rbenv-use",          repo: "https://github.com/rkh/rbenv-use.git",            version: "v1.0.0" }
 
 rbenv_root: "{% if rbenv.env == 'system' %}/usr/local/rbenv{% else %}~/.rbenv{% endif %}"
 


### PR DESCRIPTION
Updated version includes a fix for using the newly installed ruby version rather than relying on a system rubygems installation.

This fixes issues where default-gems (such as bundler) don't get installed after a new ruby-build installation.