### PR TITLE
replace sudo and sudo_user with become and become_user

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   require_ansible_repo: true
   ansible_verbose: true
   ansible_verbosity: 1
-  sudo: true
+  become: true
   extra_vars:
     rbenv:
       env: system

--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -1,6 +1,6 @@
 - name: update apt cache
   apt: update_cache=yes
-  sudo: true
+  become: true
   tags:
     - rbenv
 
@@ -16,7 +16,7 @@
     - libxml2-dev
     - libxslt1-dev
     - zlib1g-dev
-  sudo: true
+  become: true
   tags:
     - rbenv
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,8 +49,8 @@
     accept_hostkey=true
     force=yes
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when: rbenv.env != "system"
   ignore_errors: true
   tags:
@@ -59,8 +59,8 @@
 - name: create plugins directory for selected users
   file: state=directory path={{ rbenv_root }}/plugins
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when: rbenv.env != "system"
   ignore_errors: true
   tags:
@@ -76,8 +76,8 @@
   with_nested:
     - rbenv_users
     - rbenv_plugins
-  sudo: true
-  sudo_user: "{{ item[0] }}"
+  become: true
+  become_user: "{{ item[0] }}"
   when: rbenv.env != "system"
   ignore_errors: true
   tags:
@@ -85,7 +85,7 @@
 
 - name: add rbenv initialization to profile system-wide
   template: src=rbenv.sh.j2 dest=/etc/profile.d/rbenv.sh owner=root group=root mode=0755
-  sudo: true
+  become: true
   when:
     - ansible_os_family != 'OpenBSD'
   tags:
@@ -94,8 +94,8 @@
 - name: set default-gems for select users
   copy: src=default-gems dest={{ rbenv_root }}/default-gems
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when:
     - not "system" == "{{ rbenv.env }}"
     - default_gems_file is not defined
@@ -106,8 +106,8 @@
 - name: set custom default-gems for select users
   copy: src={{ default_gems_file }} dest={{ rbenv_root }}/default-gems
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when:
     - not "system" == "{{ rbenv.env }}"
     - default_gems_file is defined
@@ -118,8 +118,8 @@
 - name: set gemrc for select users
   copy: src=gemrc dest=~/.gemrc
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when: rbenv.env != "system"
   ignore_errors: true
   tags:
@@ -128,8 +128,8 @@
 - name: set vars for select users
   copy: src=vars dest={{ rbenv_root }}/vars
   with_items: rbenv_users
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   when: rbenv.env != "system"
   ignore_errors: true
   tags:
@@ -173,8 +173,8 @@
 
 - name: check ruby {{ rbenv.ruby_version }} installed for select users
   shell: $SHELL -lc "rbenv versions | grep {{ rbenv.ruby_version }}"
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   with_items: rbenv_users
   when: rbenv.env != "system"
   register: ruby_installed
@@ -186,8 +186,8 @@
 
 - name: install ruby {{ rbenv.ruby_version }} for select users
   shell: $SHELL -lc "rbenv install {{ rbenv.ruby_version }}"
-  sudo: true
-  sudo_user: "{{ item[1] }}"
+  become: true
+  become_user: "{{ item[1] }}"
   with_together:
     - ruby_installed.results
     - rbenv_users
@@ -200,8 +200,8 @@
 
 - name: check if user ruby version is {{ rbenv.ruby_version }}
   shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.ruby_version }}'"
-  sudo: true
-  sudo_user: "{{ item }}"
+  become: true
+  become_user: "{{ item }}"
   with_items: rbenv_users
   when: rbenv.env != "system"
   register: ruby_selected
@@ -213,8 +213,8 @@
 
 - name: set ruby {{ rbenv.ruby_version }} for select users
   shell: $SHELL -lc "rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
-  sudo: true
-  sudo_user: "{{ item[1] }}"
+  become: true
+  become_user: "{{ item[1] }}"
   with_together:
     - ruby_selected.results
     - rbenv_users

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -9,7 +9,7 @@
     - zlib-devel
     - libffi-devel
     - git
-  sudo: true
+  become: true
   tags:
     - rbenv
 


### PR DESCRIPTION
Replace deprecated sudo and sudo_user calls with become and become_user (simple search and replace) to kill deprecation warnings in ansible >2.0