### PR TITLE
modify gemrc to replace --rdoc and --ri.

### DIFF
--- a/files/gemrc
+++ b/files/gemrc
@@ -1,4 +1,5 @@
 ---
 :sources:
 - https://rubygems.org
-gem: --no-ri --no-rdoc
+install: --no-document
+update: --no-document


### PR DESCRIPTION
--rdoc and --ri deprecated option from 2.x
(But under 1.9.x versions uses only --rdoc and --ri.)
http://guides.rubygems.org/command-reference/#gem-install
https://github.com/rubygems/rubygems/commit/0d22d602

In accordance with the current situation, I modified that.