### PR TITLE
Fix the currently broken built (Travis doesn't support python on OS X)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,3 @@ script:
   - ansible-playbook -i inventory role.yml --connection=local --sudo -vvvv
 os:
   - linux
-  - osx


### PR DESCRIPTION
The build is currently broken, because travis apparently doesn't support python on OS x (although I'm surprised the travis script ever worked, since it relies on `apt-get`. 