### PR TITLE
Darwin doesn't have a root group either.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -128,7 +128,7 @@
   template: src=rbenv.sh.j2 dest=/etc/profile.d/rbenv.sh owner=root group=root mode=0755
   become: yes
   when:
-    - ansible_os_family != 'OpenBSD'
+    - ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin'
   tags:
     - rbenv
 


### PR DESCRIPTION
Ran into this when provisioning my Macbook. I don't believe there's a `/etc/profile.d` either. Should suffice since you're generally gonna want rbenv installed as a user anyway.