### PR TITLE
Allow for a configurable TMPDIR when installing rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Description:
 - ` default_gems_file ` - This is Rbenv's plugin _rbenv-default-gems_. Sets the path to a default-gems file of your choice (_don't set it_ if you want to use the default file `files/default-gems`)
 - ` rbenv_owner ` - The user  owning `rbenv_root` when `rbenv.env` is `system`
 - ` rbenv_group ` - The group owning `rbenv_root` when `rbenv.env` is `system`
+- ` rbenv_tmpdir ` - A temporary directory path used for artifacts when installing rubies. Defaults to system's `$TMPDIR`
 
 Example:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -176,6 +176,21 @@
   tags:
     - rbenv
 
+- name: set tmp directory path
+  set_fact: rbenv_tmpdir="{{ lookup('env', 'TMPDIR') }}"
+  when: rbenv_tmpdir is undefined
+  tags:
+    - rbenv
+
+- name: ensure tmp directory is present
+  file: state=directory path={{ rbenv_root }}/{{ rbenv_tmpdir }}
+  with_items: "{{ rbenv_users }}"
+  become: yes
+  become_user: "{{ item }}"
+  ignore_errors: yes
+  tags:
+    - rbenv
+
 - name: check ruby {{ rbenv.ruby_version }} installed for system
   shell: $SHELL -lc "rbenv versions | grep {{ rbenv.ruby_version }}"
   register: ruby_installed
@@ -193,6 +208,8 @@
   when:
     - rbenv.env == "system"
     - ruby_installed.rc != 0
+  environment:
+    TMPDIR: "{{ rbenv_tmpdir }}"
   tags:
     - rbenv
 
@@ -241,6 +258,8 @@
     - rbenv.env != "system"
     - item[0].rc != 0
   ignore_errors: yes
+  environment:
+    TMPDIR: "{{ rbenv_tmpdir }}"
   tags:
     - rbenv
 


### PR DESCRIPTION
Had an issue with a couple of servers where default `TMPDIR` was mounted as a `noexec` mount and because there's no good way of passing env variables into roles, here's a change that will allow for that. `rbenv_tmpdir` will only be used when installing rubies.