### PR TITLE
Add dnf support to install dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,9 @@ galaxy_info:
         - saucy    # 13.10
         - trusty   # 14.04
         # - utopic   # 14.10
+    - name: Fedora
+      versions:
+        - 24
   categories:
     - development
     - system

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -1,0 +1,14 @@
+---
+- name: install build depends
+  dnf: name={{ item }} state=present
+  with_items:
+    - gcc
+    - openssl-devel
+    - libyaml-devel
+    - readline-devel
+    - zlib-devel
+    - libffi-devel
+    - git
+  become: true
+  tags:
+    - rbenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,8 @@
   when: ansible_pkg_mgr == 'apt'
 - include: yum_build_depends.yml
   when: ansible_pkg_mgr == 'yum'
+- include: dnf_build_depends.yml
+  when: ansible_pkg_mgr == 'dnf'
 # - include: pacman_build_depends.yml # Arch Linux
 #   when: ansible_pkg_mgr == 'pacman'
 - include: homebrew_build_depends.yml


### PR DESCRIPTION
Hey,

I'm using Fedora as my development box on Vagrant and I got a problem with installing ruby with this role: on latest Fedora version DNF installed as default package manager so `ansible_pkg_mgr ` returns `'dnf'` instead of `'yum'`.  I've added the task to install dependencies via DNF. 

Please let me know if something wrong with this PR.
Thanks.