### PR TITLE
Fix OSX user install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,15 +22,6 @@
   tags:
     - rbenv
 
-- name: ensure tmp directory is present
-  file: state=directory path={{ rbenv_root }}/{{ rbenv_tmpdir }}
-  with_items: "{{ rbenv_users }}"
-  become: yes
-  become_user: "{{ item }}"
-  ignore_errors: yes
-  tags:
-    - rbenv
-
 - include: system_install.yml
   when: rbenv.env == "system"
 - include: user_install.yml

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -1,4 +1,13 @@
 ---
+- name: ensure tmp directory is present
+  file: state=directory path={{ rbenv_root }}/{{ rbenv_tmpdir }}
+  with_items: "{{ rbenv_users }}"
+  become: yes
+  become_user: "{{ item }}"
+  ignore_errors: yes
+  tags:
+    - rbenv
+
 - name: checkout rbenv_repo for system
   become: yes
   become_user: '{{ rbenv_owner }}'

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -87,7 +87,7 @@
     - rbenv
 
 - name: check ruby {{ rbenv.ruby_version }} installed for select users
-  shell: $SHELL -lc "rbenv versions | grep {{ rbenv.ruby_version }}"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions | grep {{ rbenv.ruby_version }}"
   become: yes
   become_user: "{{ item }}"
   with_items: "{{ rbenv_users }}"
@@ -100,7 +100,7 @@
     - rbenv
 
 - name: install ruby {{ rbenv.ruby_version }} for select users
-  shell: $SHELL -lc "rbenv install {{ rbenv.ruby_version }}"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install {{ rbenv.ruby_version }}"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:
@@ -115,7 +115,7 @@
     - rbenv
 
 - name: check if user ruby version is {{ rbenv.ruby_version }}
-  shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.ruby_version }}'"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.ruby_version }}'"
   become: yes
   become_user: "{{ item }}"
   with_items: "{{ rbenv_users }}"
@@ -128,7 +128,7 @@
     - rbenv
 
 - name: set ruby {{ rbenv.ruby_version }} for select users
-  shell: $SHELL -lc "rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.ruby_version }} && rbenv rehash"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -46,6 +46,14 @@
   tags:
     - rbenv
 
+- name: add rbenv initialization to profile system-wide
+  blockinfile: block="{{ lookup('template', 'rbenv_user.sh.j2') }}" dest=/etc/profile
+  become: yes
+  when:
+    - ansible_os_family == 'Darwin'
+  tags:
+    - rbenv
+
 - name: set default-gems for select users
   copy: src=default-gems dest={{ rbenv_root }}/default-gems
   with_items: "{{ rbenv_users }}"


### PR DESCRIPTION
The tmpdir presence task creates ~/.rbenv, which prevents subsequent tasks from cloning to ~/.rbenv. If it's simply removed, the cloning task works fine. As well, since the shell is not refreshed between tasks, ansible can't find the rbenv bin without an explicit path.