### PR TITLE
make debian apt cache update idempotent and valid for a minimum period

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -1,6 +1,7 @@
 - name: update apt cache
-  apt: update_cache=yes
+  apt: update_cache=yes cache_valid_time=86400
   become: true
+  changed_when: false
   tags:
     - rbenv
 
@@ -19,4 +20,3 @@
   become: true
   tags:
     - rbenv
-


### PR DESCRIPTION
concept borrowed from other popular roles such as
https://github.com/geerlingguy/ansible-role-nginx/blob/master/tasks/setup-Debian.yml