### PR TITLE
use master branch for ruby-build plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Default variables are:
 
       - { name: "ruby-build",
           repo: "https://github.com/rbenv/ruby-build.git",
-          version: "v20161121" }
+          version: "master" }
 
       - { name: "rbenv-default-gems",
           repo: "https://github.com/rbenv/rbenv-default-gems.git",

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
 rbenv_plugins:
   - { name: "rbenv-vars",         repo: "https://github.com/rbenv/rbenv-vars.git",         version: "v1.2.0" }
-  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "v20161121" }
+  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "master" }
   - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "ead67889c91c53ad967f85f5a89d986fdb98f6fb" }
   - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "bc21e7055dcc8f5f9bc66ce0c78cc9ae0c28cd7a" }
   - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "1961fa180280bb50b64cbbffe6a5df7cf70f5e50" }


### PR DESCRIPTION
The ruby-build plugin updates very regularly with new ruby versions.
The plugin itself appears to expect that master branch is used; for example, the instructions that it issues if an attempt is made to install a missing version are
https://github.com/rbenv/ruby-build/blob/d6641376641b3a54aab7a02e1d81b26e95e16bb5/bin/rbenv-install#L218

```
cd ~/.rbenv/plugins/ruby-build && git pull && cd -
```

which doesn't work if we pin to a release version.

In my experience releases are backwards compatible so there seems little point to avoid using master.