### PR TITLE
Fix usage of tmp dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   set_fact: 'rbenv_owner={{ rbenv_owner | default("root", true) }}'
 
 - name: set tmp directory path
-  set_fact: rbenv_tmpdir="{{ lookup('env', 'TMPDIR') }}"
+  set_fact: rbenv_tmpdir="{{ ansible_env.TMPDIR | default('/tmp') }}"
   when: rbenv_tmpdir is undefined
   tags:
     - rbenv

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -1,13 +1,4 @@
 ---
-- name: ensure tmp directory is present
-  file: state=directory path={{ rbenv_root }}/{{ rbenv_tmpdir }}
-  with_items: "{{ rbenv_users }}"
-  become: yes
-  become_user: "{{ item }}"
-  ignore_errors: yes
-  tags:
-    - rbenv
-
 - name: checkout rbenv_repo for system
   become: yes
   become_user: '{{ rbenv_owner }}'


### PR DESCRIPTION
As per discussion on https://github.com/zzet/ansible-rbenv-role/pull/74#issuecomment-266468021

The idea of this variable was to use the remote env var but lookup actually pulls from the Ansible control machine. This fixes that and uses the same default as the upstream ruby-build process
https://github.com/rbenv/ruby-build/blob/master/bin/ruby-build#L1211