### PR TITLE
Disable install rdoc on ruby installation

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -81,7 +81,7 @@
     - rbenv
 
 - name: install ruby {{ rbenv.ruby_version }} for system
-  shell: bash -lc "rbenv install {{ rbenv.ruby_version }}"
+  shell: bash -lc "CONFIGURE_OPTS='--disable-install-rdoc' rbenv install {{ rbenv.ruby_version }}"
   become: yes
   when:
     - ruby_installed.rc != 0

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -108,7 +108,7 @@
     - rbenv
 
 - name: install ruby {{ rbenv.ruby_version }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install {{ rbenv.ruby_version }}"
+  shell: $SHELL -lc "CONFIGURE_OPTS='--disable-install-rdoc' {{ rbenv_root }}/bin/rbenv install {{ rbenv.ruby_version }}"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:


### PR DESCRIPTION
On VMs with 512Mb ram rbenv install fails with the following error:

```
deploy@vagrant-ubuntu-trusty-64:~$ ~/.rbenv/bin/rbenv install 2.3.3
Downloading ruby-2.3.3.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2
Installing ruby-2.3.3...

BUILD FAILED (Ubuntu 14.04 using ruby-build 20161121-14-gd799bdd)

Inspect or clean up the working tree at /tmp/ruby-build.20161220100047.23023
Results logged to /tmp/ruby-build.20161220100047.23023.log

Last 10 log lines:
 99% [941/946]  vm_eval.c
 99% [942/946]  vm_exec.c
 99% [943/946]  vm_insnhelper.c
 99% [944/946]  vm_method.c
 99% [945/946]  vm_trace.c
100% [946/946]  vsnprintf.c

Generating RI format into /tmp/ruby-build.20161220100047.23023/ruby-2.3.3/.ext/rdoc...
Killed
make: *** [rdoc] Error 137
```

This modification is to ensure there is no documentation to set up during the installation:

```
deploy@vagrant-ubuntu-trusty-64:~$ CONFIGURE_OPTS='--disable-install-rdoc' ~/.rbenv/bin/rbenv install 2.3.3
Downloading ruby-2.3.3.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2
Installing ruby-2.3.3...
Installed ruby-2.3.3 to /home/deploy/.rbenv/versions/2.3.3

Fetching: bundler-1.13.6.gem (100%)
Successfully installed bundler-1.13.6
1 gem installed
```