### PR TITLE
remove inconsistently used tags

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -2,8 +2,6 @@
   apt: update_cache=yes cache_valid_time=86400
   become: true
   changed_when: false
-  tags:
-    - rbenv
 
 - name: install build depends
   apt: pkg={{ item }} state=present install_recommends=no
@@ -18,5 +16,3 @@
     - libxslt1-dev
     - zlib1g-dev
   become: true
-  tags:
-    - rbenv

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -10,5 +10,3 @@
     - libffi-devel
     - git
   become: true
-  tags:
-    - rbenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,6 @@
 - name: set tmp directory path
   set_fact: rbenv_tmpdir="{{ ansible_env.TMPDIR | default('/tmp') }}"
   when: rbenv_tmpdir is undefined
-  tags:
-    - rbenv
 
 - include: system_install.yml
   when: rbenv.env == "system"

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -8,15 +8,11 @@
     version={{ rbenv.version }}
     accept_hostkey=yes
     force=yes
-  tags:
-    - rbenv
 
 - name: create plugins directory for system
   become: yes
   become_user: '{{ rbenv_owner }}'
   file: state=directory path={{ rbenv_root }}/plugins
-  tags:
-    - rbenv
 
 - name: install plugins for system
   become: yes
@@ -28,16 +24,12 @@
     accept_hostkey=yes
     force=yes
   with_items: "{{ rbenv_plugins }}"
-  tags:
-    - rbenv
 
 - name: add rbenv initialization to profile system-wide
   template: src=rbenv_system.sh.j2 dest=/etc/profile.d/rbenv.sh owner=root group=root mode=0755
   become: yes
   when:
     - ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin'
-  tags:
-    - rbenv
 
 - name: Set group ownership of content under rbenv_root
   shell:
@@ -52,8 +44,6 @@
     - rbenv_group != None
   register: rbenv_chgrp
   changed_when: '"changed group" in rbenv_chgrp.stdout'
-  tags:
-    - rbenv
 
 - name: Set group permissions of content under rbenv_root
   shell:
@@ -67,8 +57,6 @@
     - rbenv_group != None
   register: rbenv_chmod
   changed_when: '"changed from" in rbenv_chmod.stdout'
-  tags:
-    - rbenv
 
 - name: check ruby versions installed for system
   shell: $SHELL -lc "rbenv versions | grep {{ item.version }}"
@@ -78,8 +66,6 @@
   ignore_errors: yes
   failed_when: false
   check_mode: no
-  tags:
-    - rbenv
 
 - name: install ruby versions for system
   shell: bash -lc "rbenv install {{ item[1].version }}"
@@ -91,8 +77,6 @@
     - item[0].rc != 0
     - item[0].item.version == item[1].version
   environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
-  tags:
-    - rbenv
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
@@ -101,13 +85,9 @@
   ignore_errors: yes
   failed_when: false
   check_mode: no
-  tags:
-    - rbenv
 
 - name: set ruby {{ rbenv.default_ruby }} for system
   become: yes
   shell: bash -lc "rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
   when:
     - ruby_selected.rc != 0
-  tags:
-    - rbenv

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -10,8 +10,6 @@
   become: yes
   become_user: "{{ item }}"
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: create plugins directory for selected users
   file: state=directory path={{ rbenv_root }}/plugins
@@ -19,8 +17,6 @@
   become: yes
   become_user: "{{ item }}"
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: install plugins for selected users
   git: >
@@ -35,24 +31,18 @@
   become: yes
   become_user: "{{ item[0] }}"
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: add rbenv initialization to profile system-wide
   template: src=rbenv_user.sh.j2 dest=/etc/profile.d/rbenv.sh owner=root group=root mode=0755
   become: yes
   when:
     - ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin'
-  tags:
-    - rbenv
 
 - name: add rbenv initialization to profile system-wide
   blockinfile: block="{{ lookup('template', 'rbenv_user.sh.j2') }}" dest=/etc/profile
   become: yes
   when:
     - ansible_os_family == 'Darwin'
-  tags:
-    - rbenv
 
 - name: set default-gems for select users
   copy: src=default-gems dest={{ rbenv_root }}/default-gems
@@ -62,8 +52,6 @@
   when:
     - default_gems_file is not defined
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: set custom default-gems for select users
   copy: src={{ default_gems_file }} dest={{ rbenv_root }}/default-gems
@@ -73,8 +61,6 @@
   when:
     - default_gems_file is defined
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: set gemrc for select users
   copy: src=gemrc dest=~/.gemrc
@@ -82,8 +68,6 @@
   become: yes
   become_user: "{{ item }}"
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: set vars for select users
   copy: src=vars dest={{ rbenv_root }}/vars
@@ -91,8 +75,6 @@
   become: yes
   become_user: "{{ item }}"
   ignore_errors: yes
-  tags:
-    - rbenv
 
 - name: check ruby versions installed for select users
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions | grep {{ item[1].version }}"
@@ -106,8 +88,6 @@
   ignore_errors: yes
   failed_when: false
   check_mode: no
-  tags:
-    - rbenv
 
 - name: install ruby {{ item[2].version }} for select users
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install {{ item[2].version }}"
@@ -123,8 +103,6 @@
     - item[0].item[1].version == item[2].version
   ignore_errors: yes
   environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
-  tags:
-    - rbenv
 
 - name: check if user ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
@@ -136,8 +114,6 @@
   ignore_errors: yes
   failed_when: false
   check_mode: no
-  tags:
-    - rbenv
 
 - name: set ruby {{ rbenv.default_ruby }} for select users
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
@@ -149,5 +125,3 @@
   when:
     - item[0].rc != 0
   ignore_errors: yes
-  tags:
-    - rbenv

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -10,6 +10,4 @@
     - libffi-devel
     - git
   become: true
-  tags:
-    - rbenv
 


### PR DESCRIPTION
A single tag does not allow segregation of tasks. In fact if this tag is currently used, it breaks the role as it is not applied to all actions.
Removing tags was an alternative approach suggested to the outstanding PR https://github.com/zzet/ansible-rbenv-role/pull/78