### PR TITLE
pump min ansible version to 2.2.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: rbenv
   company: Undev
   license: MIT
-  min_ansible_version: 1.7.1
+  min_ansible_version: 2.2.0
   version: 0.2
 
   platforms:


### PR DESCRIPTION
If you are running ansible version prior to 2.2.0 you cannot use the check mode.