### PR TITLE
Install support packages for Ruby 1.8.7 on Debian based OS

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -16,3 +16,17 @@
     - libxslt1-dev
     - zlib1g-dev
   become: true
+
+- shell: "echo '{{ rbenv.rubies | map(attribute='version') | join(' ') }}' | grep '1.8.7'"
+  ignore_errors: yes
+  register: ruby_version_1_8_7
+
+- name: Install packages required to build Ruby 1.8.7
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - bison
+    - autoconf
+    - subversion
+  when: ruby_version_1_8_7.rc == 0


### PR DESCRIPTION
For those poor souls who still have to use Ruby 1.8. Tested against a vanilla Ubuntu 14.04 install.