### PR TITLE
ensure bzip is installed on RHEL/CentOS

### DIFF
--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -2,12 +2,12 @@
 - name: install build depends
   yum: name={{ item }} state=present
   with_items:
+    - bzip2
     - gcc
-    - openssl-devel
+    - git
+    - libffi-devel
     - libyaml-devel
+    - openssl-devel
     - readline-devel
     - zlib-devel
-    - libffi-devel
-    - git
   become: true
-


### PR DESCRIPTION
DigitalOcean droplets running CentOS do not, by default.