### PR TITLE
Add an option to install extra packages before building ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Default variables are:
     rbenv_root: "{% if rbenv.env == 'system' %}/usr/local/rbenv{% else %}$HOME/.rbenv{% endif %}"
 
     rbenv_users: []
+    
+    rbenv_extra_depends: []
 
 Variables to control a system installation (these are not set by default):
 
@@ -75,6 +77,7 @@ Description:
 - ` rbenv_plugins ` - Array of Hashes with information about plugins to install
 - ` rbenv_root ` - Install path
 - ` rbenv_users ` - Array of usernames for multiuser install. User must be present in the system
+- ` rbenv_extra_depends` - Array of extra system packages to install before compiling rubies
 - ` default_gems_file ` - This is Rbenv's plugin _rbenv-default-gems_. Sets the path to a default-gems file of your choice (_don't set it_ if you want to use the default file `files/default-gems`)
 - ` rbenv_owner ` - The user  owning `rbenv_root` when `rbenv.env` is `system`
 - ` rbenv_group ` - The group owning `rbenv_root` when `rbenv.env` is `system`
@@ -94,6 +97,12 @@ Example:
           - version: 2.2.4
             env:
               RUBY_CONFIGURE_OPTS: "--enable-shared"
+          - version: 2.3.4
+            env:
+              RUBY_CONFIGURE_OPTS: "--enable-shared --with-jemalloc"
+          rbenv_extra_depends:
+            - libjemalloc1
+            - libjemalloc-dev
       roles:
         - role: zzet.rbenv
           rbenv_users:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ rbenv_plugins:
 rbenv_root: "{% if rbenv.env == 'system' %}/usr/local/rbenv{% else %}~/.rbenv{% endif %}"
 
 rbenv_users: []
+
+rbenv_extra_depends: []

--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -17,6 +17,11 @@
     - zlib1g-dev
   become: true
 
+- name: install extra build depends
+  apt: pkg={{ item }} state=present install_recommends=no
+  with_items: '{{ rbenv_extra_depends }}'
+  become: true
+
 - shell: "echo '{{ rbenv.rubies | map(attribute='version') | join(' ') }}' | grep '1.8.7'"
   ignore_errors: yes
   register: ruby_version_1_8_7

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -10,3 +10,8 @@
     - libffi-devel
     - git
   become: true
+
+- name: install build depends
+  dnf: name={{ item }} state=present
+  with_items: '{{ rbenv_extra_depends }}'
+  become: true

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -11,3 +11,8 @@
     - readline-devel
     - zlib-devel
   become: true
+
+- name: install extra build depends
+  yum: name={{ item }} state=present
+  with_items: '{{ rbenv_extra_depends }}'
+  become: true


### PR DESCRIPTION
Some ruby compilation flags may require extra dependencies to be installed on the machines.

For example, `--with-jmalloc` requires `libjemalloc-dev` to be installed on Debian, otherwise ruby compilation fails.

This PR adds a feature to install the required system packages before compiling rubies.