### PR TITLE
Add option to clean up old rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Default variables are:
       rubies:
         - version: 2.3.3
 
+    rbenv_clean_up: false
+
     rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
     rbenv_plugins:
@@ -73,6 +75,7 @@ Description:
 - ` rbenv.version ` - Version of rbenv to install (tag from [rbenv releases page](https://github.com/sstephenson/rbenv/releases))
 - ` rbenv.default_ruby ` - Which ruby version to be set as global rbenv ruby.
 - ` rbenv.rubies ` - Versions of ruby to install. This is an array of hashes. E.g. `[ { version: 2.3.3, env: { RUBY_CONFIGURE_OPTS="--enable-shared" } } ]`
+- ` rbenv_clean_up ` - Delete all ruby versions not listed above. Default value is `false`
 - ` rbenv_repo ` - Repository with source code of rbenv to install
 - ` rbenv_plugins ` - Array of Hashes with information about plugins to install
 - ` rbenv_root ` - Install path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ rbenv:
   rubies:
     - version: 2.3.3
 
+rbenv_clean_up: false
+
 rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
 rbenv_plugins:

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -59,10 +59,9 @@
   changed_when: '"changed from" in rbenv_chmod.stdout'
 
 - name: check ruby versions installed for system
-  shell: $SHELL -lc "rbenv versions | grep {{ item.version }}"
+  shell: $SHELL -lc "rbenv versions --bare"
   register: ruby_installed
   changed_when: false
-  with_items: '{{ rbenv.rubies }}'
   ignore_errors: yes
   failed_when: false
   check_mode: no
@@ -74,9 +73,28 @@
     - '{{ ruby_installed.results }}'
     - '{{ rbenv.rubies }}'
   when:
-    - item[0].rc != 0
-    - item[0].item.version == item[1].version
+    - item[1].version not in item[0].stdout_lines
   environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
+
+- name: check which old rubies to remove for system
+  set_fact:
+    drop_ruby: "{{ '{'+item[0].stdout_lines|list|difference(item[1])|join(',')+'}'}}"
+  become: yes
+  with_nested:
+    - "{{ ruby_installed.results }}"
+    - "{{ rbenv.rubies|map(attribute='version')|list }}"
+  when:
+    - rbenv_clean_up
+    - item[0].stdout_lines|list != item[1]
+  register: removable_rubies
+  ignore_errors: yes
+
+- name: remove old rubies
+  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
+  changed_when: false
+  become: yes
+  when: rbenv_clean_up
+  ignore_errors: yes
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -77,7 +77,7 @@
   ignore_errors: yes
 
 - name: check ruby versions installed for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions | grep {{ item[1].version }}"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
   become: yes
   become_user: "{{ item[0] }}"
   with_nested:
@@ -98,11 +98,37 @@
     - "{{ rbenv_users }}"
     - "{{ rbenv.rubies }}"
   when:
-    - item[0].rc != 0
     - item[0].item[0] == item[1]
-    - item[0].item[1].version == item[2].version
+    - item[2].version not in item[0].stdout_lines
   ignore_errors: yes
   environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
+
+- name: check which old rubies to remove for select users
+  set_fact:
+    drop_ruby:
+      - "{{ item[1] }}"
+      - "{{ '{'+item[0].stdout_lines|list|difference(item[2])|join(',')+'}'}}"
+  become: yes
+  become_user: "{{ item[1] }}"
+  with_nested:
+    - "{{ ruby_installed.results }}"
+    - "{{ rbenv_users }}"
+    - "{{ rbenv.rubies|map(attribute='version')|list }}"
+  when:
+    - rbenv_clean_up
+    - item[0].item[0] == item[1]
+    - item[0].stdout_lines|list != item[2]
+  register: removable_rubies
+  ignore_errors: yes
+
+- name: remove old rubies
+  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
+  changed_when: false
+  become: yes
+  become_user: "{{ item.ansible_facts.drop_ruby[0] }}"
+  with_items: "{{ removable_rubies.results }}"
+  when: rbenv_clean_up
+  ignore_errors: yes
 
 - name: check if user ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"


### PR DESCRIPTION
I've added the `rbenv_clean_up` option.

I have tested this on my user install, but not on system. I also don't know how you run the tests.
Please test and see if I should fix anything.

I changed the `ruby_installed` variable to just list all installed rubies, rather than loop over what to install.
The install ruby tasks are adjusted to fit with this. It works in user install.