### PR TITLE
Clean up old rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Default variables are:
       rubies:
         - version: 2.3.3
 
+    rbenv_clean_up: false
+
     rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
     rbenv_plugins:
@@ -73,6 +75,7 @@ Description:
 - ` rbenv.version ` - Version of rbenv to install (tag from [rbenv releases page](https://github.com/sstephenson/rbenv/releases))
 - ` rbenv.default_ruby ` - Which ruby version to be set as global rbenv ruby.
 - ` rbenv.rubies ` - Versions of ruby to install. This is an array of hashes. E.g. `[ { version: 2.3.3, env: { RUBY_CONFIGURE_OPTS="--enable-shared" } } ]`
+- ` rbenv_clean_up ` - Delete all ruby versions not listed above. Default value is `false`
 - ` rbenv_repo ` - Repository with source code of rbenv to install
 - ` rbenv_plugins ` - Array of Hashes with information about plugins to install
 - ` rbenv_root ` - Install path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ rbenv:
   rubies:
     - version: 2.3.3
 
+rbenv_clean_up: false
+
 rbenv_repo: "https://github.com/rbenv/rbenv.git"
 
 rbenv_plugins:

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -78,6 +78,26 @@
     - item[1].version not in item[0].stdout_lines
   environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 
+- name: check which old rubies to remove for system
+  set_fact:
+    drop_ruby: "{{ '{'+item[0].stdout_lines|list|difference(item[1])|join(',')+'}'}}"
+  become: yes
+  with_nested:
+    - "{{ rbenv_versions.results }}"
+    - "{{ rbenv.rubies|map(attribute='version')|list }}"
+  when:
+    - rbenv_clean_up
+    - item[0].stdout_lines|list != item[1]
+  register: removable_rubies
+  ignore_errors: yes
+
+- name: remove old rubies
+  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
+  changed_when: false
+  become: yes
+  when: rbenv_clean_up
+  ignore_errors: yes
+
 - name: check if current system ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   register: ruby_selected

--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -59,10 +59,10 @@
   changed_when: '"changed from" in rbenv_chmod.stdout'
 
 - name: check ruby versions installed for system
-  shell: $SHELL -lc "rbenv versions | grep {{ item.version }}"
-  register: ruby_installed
+  shell: $SHELL -lc "rbenv versions --bare"
+  register: rbenv_versions
+  with_items: rbenv.rubies
   changed_when: false
-  with_items: '{{ rbenv.rubies }}'
   ignore_errors: yes
   failed_when: false
   check_mode: no
@@ -71,11 +71,11 @@
   shell: bash -lc "rbenv install {{ item[1].version }}"
   become: yes
   with_nested:
-    - '{{ ruby_installed.results }}'
+    - '{{ rbenv_versions.results }}'
     - '{{ rbenv.rubies }}'
   when:
-    - item[0].rc != 0
-    - item[0].item.version == item[1].version
+    - item[0].rc == 0
+    - item[1].version not in item[0].stdout_lines
   environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -102,6 +102,33 @@
   ignore_errors: yes
   environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 
+- name: check which old rubies to remove for select users
+  set_fact:
+    drop_ruby:
+      - "{{ item[1] }}"
+      - "{{ '{'+item[0].stdout_lines|list|difference(item[2])|join(',')+'}'}}"
+  become: yes
+  become_user: "{{ item[1] }}"
+  with_nested:
+    - "{{ ruby_installed.results }}"
+    - "{{ rbenv_users }}"
+    - "{{ rbenv.rubies|map(attribute='version')|list }}"
+  when:
+    - rbenv_clean_up
+    - item[0].item[0] == item[1]
+    - item[0].stdout_lines|list != item[2]
+  register: removable_rubies
+  ignore_errors: yes
+
+- name: remove old rubies
+  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
+  changed_when: false
+  become: yes
+  become_user: "{{ item.ansible_facts.drop_ruby[0] }}"
+  with_items: "{{ removable_rubies.results }}"
+  when: rbenv_clean_up
+  ignore_errors: yes
+
 - name: check if user ruby version is {{ rbenv.default_ruby }}
   shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   become: yes

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -77,13 +77,11 @@
   ignore_errors: yes
 
 - name: check ruby versions installed for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions | grep {{ item[1].version }}"
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
+  with_items: "{{ rbenv_users }}"
   become: yes
-  become_user: "{{ item[0] }}"
-  with_nested:
-    - "{{ rbenv_users }}"
-    - "{{ rbenv.rubies }}"
-  register: ruby_installed
+  become_user: "{{ item }}"
+  register: rbenv_versions
   changed_when: false
   ignore_errors: yes
   failed_when: false
@@ -94,13 +92,13 @@
   become: yes
   become_user: "{{ item[1] }}"
   with_nested:
-    - "{{ ruby_installed.results }}"
+    - "{{ rbenv_versions.results }}"
     - "{{ rbenv_users }}"
     - "{{ rbenv.rubies }}"
   when:
-    - item[0].rc != 0
+    - item[0].rc == 0
     - item[0].item[0] == item[1]
-    - item[0].item[1].version == item[2].version
+    - item[2].version not in item[0].stdout_lines
   ignore_errors: yes
   environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 


### PR DESCRIPTION
Please merge the rbenv versions PR before this one.

Compares the installed rubies list with the `rbenv.rubies` variable to decide which rubies are not wanted at the target system anymore.

All ruby versions not listed in `rbenv.rubies` will be removed.