### PR TITLE
Fixes #102: conditional arg item[0] turn into item.

### DIFF
--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -97,7 +97,7 @@
     - "{{ rbenv.rubies }}"
   when:
     - item[0].rc == 0
-    - item[0].item[0] == item[1]
+    - item[0].item == item[1]
     - item[2].version not in item[0].stdout_lines
   ignore_errors: yes
   environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"


### PR DESCRIPTION
The conditional is not correct. If you keep the last `[0]` it returns the first character of the `item[0].item`.

And of course the conditional is never met and so the ruby is never installed.