### PR TITLE
set default-gems for system-wide installation

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -31,6 +31,24 @@
   when:
     - ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin'
 
+- name: set default-gems for system
+  copy: src=default-gems dest={{ rbenv_root }}/default-gems
+  with_items: "{{ rbenv_owner }}"
+  become: yes
+  become_user: "{{ item }}"
+  when:
+    - default_gems_file is not defined
+  ignore_errors: yes
+
+- name: set custom default-gems for system
+  copy: src={{ default_gems_file }} dest={{ rbenv_root }}/default-gems
+  with_items: "{{ rbenv_owner }}"
+  become: yes
+  become_user: "{{ item }}"
+  when:
+    - default_gems_file is defined
+  ignore_errors: yes
+
 - name: Set group ownership of content under rbenv_root
   shell:
     find '{{ rbenv_root }}'


### PR DESCRIPTION
rbenv-default-gems don't work for system-wide installation because default-gems file is not set.
Fixed it.