### PR TITLE
Creation of Prerequisite Packages variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,30 @@ rbenv_root: "{% if rbenv.env == 'system' %}/usr/local/rbenv{% else %}~/.rbenv{% 
 rbenv_users: []
 
 rbenv_extra_depends: []
+rbenv_apt_packages:
+- build-essential
+- git
+- libcurl4-openssl-dev
+- libffi-dev
+- libreadline-dev
+- libssl-dev
+- libxml2-dev
+- libxslt1-dev
+- zlib1g-dev
+rbenv_dnf_packages:
+- gcc
+- openssl-devel
+- libyaml-devel
+- readline-devel
+- zlib-devel
+- libffi-devel
+- git
+rbenv_yum_packages:
+- bzip2
+- gcc
+- git
+- libffi-devel
+- libyaml-devel
+- openssl-devel
+- readline-devel
+- zlib-devel

--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -6,15 +6,7 @@
 - name: install build depends
   apt: pkg={{ item }} state=present install_recommends=no
   with_items:
-    - build-essential
-    - git
-    - libcurl4-openssl-dev
-    - libffi-dev
-    - libreadline-dev
-    - libssl-dev
-    - libxml2-dev
-    - libxslt1-dev
-    - zlib1g-dev
+  - "{{ rbenv_apt_packages }}"
   become: true
 
 - name: install extra build depends

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -2,13 +2,7 @@
 - name: install build depends
   dnf: name={{ item }} state=present
   with_items:
-    - gcc
-    - openssl-devel
-    - libyaml-devel
-    - readline-devel
-    - zlib-devel
-    - libffi-devel
-    - git
+  - "{{ rbenv_dnf_packages }}"
   become: true
 
 - name: install build depends

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -2,14 +2,7 @@
 - name: install build depends
   yum: name={{ item }} state=present
   with_items:
-    - bzip2
-    - gcc
-    - git
-    - libffi-devel
-    - libyaml-devel
-    - openssl-devel
-    - readline-devel
-    - zlib-devel
+  - "{{ rbenv_yum_packages }}"
   become: true
 
 - name: install extra build depends


### PR DESCRIPTION
My use case is to install a Ruby 2.3.3 on a debian.
As you can read in the link below, I do not need the package `libssl-dev` (which is now in version 1.1) but the previous `libssl1.0-dev`. And your role install the lastest version (Cf. [line 14](https://github.com/zzet/ansible-rbenv-role/blob/master/tasks/apt_build_depends.yml#L14)).

I know that you propose a `rbenv_extra_depends` but this is an addition and not a modification of the packages to install.
In order to be able to tweak the prequisite packages I suggest to proceed with default variables. One variable per package manager.

This feature is an answer to my use case, but can be useful to other situation.

Source : https://github.com/rbenv/ruby-build/issues/1048#issuecomment-275152741