### PR TITLE
Ruby 1.8.7 case improvement.

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -22,11 +22,11 @@
   with_items: '{{ rbenv_extra_depends }}'
   become: true
 
-- shell: "echo '{{ rbenv.rubies | map(attribute='version') | join(' ') }}' | grep '1.8.7'"
-  ignore_errors: yes
-  register: ruby_version_1_8_7
-  check_mode: no
-  changed_when: false
+- name: Create the list of ruby versions.
+  set_fact:
+    rbenv_ruby_versions: "{{ rbenv_ruby_versions | default([]) }} + {{ [item.version] }}"
+  with_items:
+  - "{{ rbenv.rubies }}"
 
 - name: Install packages required to build Ruby 1.8.7
   apt:
@@ -36,4 +36,4 @@
     - bison
     - autoconf
     - subversion
-  when: ruby_version_1_8_7.rc == 0
+  when: "'1.8.7' in rbenv_ruby_versions"


### PR DESCRIPTION
In order to improve the use case of the ruby 1.8.7, I propose this PR.

The benefits are :

1. Remove an ignore_errors
2. Remove a non-recommended `shell`
3. Improve idempotence
