### PR TITLE
Fix for multiple Rubies installation

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -68,15 +68,11 @@
   check_mode: no
 
 - name: install ruby versions for system
-  shell: bash -lc "rbenv install {{ item[1].version }}"
+  shell: bash -lc "rbenv install --skip-existing {{ item.version }}"
   become: yes
-  with_nested:
-    - '{{ rbenv_versions.results }}'
+  with_items:
     - '{{ rbenv.rubies }}'
-  when:
-    - item[0].rc == 0
-    - item[1].version not in item[0].stdout_lines
-  environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
+  environment: "{{ item.env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 
 - name: check which old rubies to remove for system
   set_fact:

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -87,20 +87,15 @@
   failed_when: false
   check_mode: no
 
-- name: install ruby {{ item[2].version }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install {{ item[2].version }}"
+- name: install ruby {{ item[1].version }} for select users
+  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install --skip-existing {{ item[1].version }}"
   become: yes
-  become_user: "{{ item[1] }}"
+  become_user: "{{ item[0] }}"
   with_nested:
-    - "{{ rbenv_versions.results }}"
     - "{{ rbenv_users }}"
     - "{{ rbenv.rubies }}"
-  when:
-    - item[0].rc == 0
-    - item[0].item == item[1]
-    - item[2].version not in item[0].stdout_lines
   ignore_errors: yes
-  environment: "{{ item[2].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
+  environment: "{{ item[1].env | default({}) | combine({ 'TMPDIR': rbenv_tmpdir }) }}"
 
 - name: check which old rubies to remove for select users
   set_fact:


### PR DESCRIPTION
When the vars for multiple Rubies are specified,

(e.g.
```
rbenv:
  rubies:
    - version: 2.3.5
    - version: 2.4.2
```

The installation is failed with the following message:
```
skipping: [web] => (item=[{'_ansible_parsed': True, 'stderr_lines': [u'/bin/sh: 1: -lc: not found'], '_ansible_item_result': True, u'end': u'2017-10-04 01:09:22.817320', '_ansible_no_log': False, u'stdout': u'', u'cmd': u'$SHELL -lc "rbenv versions --bare"', u'msg': u'non-zero return code', u'rc': 127, u'start': u'2017-10-04 01:09:22.662029', u'delta': u'0:00:00.155291', 'item': u'rbenv.rubies', u'changed': False, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'$SHELL -lc "rbenv versions --bare"', u'removes': None, u'warn': True, u'chdir': None, u'stdin': None}}, 'stdout_lines': [], 'failed_when_result': False, u'stderr': u'/bin/sh: 1: -lc: not found', u'failed': False}, {u'version': u'2.3.5'}])
skipping: [web] => (item=[{'_ansible_parsed': True, 'stderr_lines': [u'/bin/sh: 1: -lc: not found'], '_ansible_item_result': True, u'end': u'2017-10-04 01:09:22.817320', '_ansible_no_log': False, u'stdout': u'', u'cmd': u'$SHELL -lc "rbenv versions --bare"', u'msg': u'non-zero return code', u'rc': 127, u'start': u'2017-10-04 01:09:22.662029', u'delta': u'0:00:00.155291', 'item': u'rbenv.rubies', u'changed': False, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'$SHELL -lc "rbenv versions --bare"', u'removes': None, u'warn': True, u'chdir': None, u'stdin': None}}, 'stdout_lines': [], 'failed_when_result': False, u'stderr': u'/bin/sh: 1: -lc: not found', u'failed': False}, {u'version': u'2.4.2'}])
```

It seems the usage of `rbenv_versions.results` is wrong.
It should not be used as a list.