### PR TITLE
Optionally do not install profile snippet for users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,4 @@ rbenv_yum_packages:
 - openssl-devel
 - readline-devel
 - zlib-devel
+rbenv_user_profile: true

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -36,13 +36,13 @@
   template: src=rbenv_user.sh.j2 dest=/etc/profile.d/rbenv.sh owner=root group=root mode=0755
   become: yes
   when:
-    - ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin'
+    - (ansible_os_family != 'OpenBSD' and ansible_os_family != 'Darwin') and rbenv_user_profile
 
 - name: add rbenv initialization to profile system-wide
   blockinfile: block="{{ lookup('template', 'rbenv_user.sh.j2') }}" dest=/etc/profile
   become: yes
   when:
-    - ansible_os_family == 'Darwin'
+    - ansible_os_family == 'Darwin' and rbenv_user_profile
 
 - name: set default-gems for select users
   copy: src=default-gems dest={{ rbenv_root }}/default-gems


### PR DESCRIPTION
I would like to use the rbenv role on systems without having to change anything outside the scope of user. This change allows the ability to disable the configuration of rbenv profile snippets. The default behaviour remains unchanged.