### PR TITLE
Harmonize syntax for extra_build_depends variable iteration

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -11,7 +11,8 @@
 
 - name: install extra build depends
   apt: pkg={{ item }} state=present install_recommends=no
-  with_items: '{{ rbenv_extra_depends }}'
+  with_items:
+  - "{{ rbenv_extra_depends }}"
   become: true
 
 - name: Create the list of ruby versions.

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -7,5 +7,6 @@
 
 - name: install build depends
   dnf: name={{ item }} state=present
-  with_items: '{{ rbenv_extra_depends }}'
+  with_items:
+  - "{{ rbenv_extra_depends }}"
   become: true

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -7,5 +7,6 @@
 
 - name: install extra build depends
   yum: name={{ item }} state=present
-  with_items: '{{ rbenv_extra_depends }}'
+  with_items:
+  - "{{ rbenv_extra_depends }}"
   become: true


### PR DESCRIPTION
`extra_build_depends` variable was apparently broken, the corresponding task was never executed.
This PR fixes the behaviour, allowing to install ruby with jemalloc.