### PR TITLE
Remove GEM_PATH overwrite

### DIFF
--- a/files/vars
+++ b/files/vars
@@ -1,1 +1,1 @@
-GEM_PATH=$GEM_PATH:$HOME/.gems
+


### PR DESCRIPTION
This messes up with bundler and rbenv, because bundler won't overwrite the GEM_PATH if it's not set to default.

I also don't think this role should be making the decision of modifying the GEM_PATH. also, the ‘vars‘ file doesn't seem to be overwritable?