### PR TITLE
Unify shell command usage to bash

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -59,7 +59,7 @@
   changed_when: '"changed from" in rbenv_chmod.stdout'
 
 - name: check ruby versions installed for system
-  shell: $SHELL -lc "rbenv versions --bare"
+  shell: bash -lc "rbenv versions --bare"
   register: rbenv_versions
   with_items: rbenv.rubies
   changed_when: false
@@ -88,14 +88,14 @@
   ignore_errors: yes
 
 - name: remove old rubies
-  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
+  shell: bash -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
   changed_when: false
   become: yes
   when: rbenv_clean_up
   ignore_errors: yes
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}
-  shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
+  shell: bash -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   register: ruby_selected
   changed_when: false
   ignore_errors: yes

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -77,7 +77,7 @@
   ignore_errors: yes
 
 - name: check ruby versions installed for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
+  shell: bash -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
   with_items: "{{ rbenv_users }}"
   become: yes
   become_user: "{{ item }}"
@@ -88,7 +88,7 @@
   check_mode: no
 
 - name: install ruby {{ item[1].version }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install --skip-existing {{ item[1].version }}"
+  shell: bash -lc "{{ rbenv_root }}/bin/rbenv install --skip-existing {{ item[1].version }}"
   become: yes
   become_user: "{{ item[0] }}"
   with_nested:
@@ -116,7 +116,7 @@
   ignore_errors: yes
 
 - name: remove old rubies
-  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
+  shell: bash -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
   changed_when: false
   become: yes
   become_user: "{{ item.ansible_facts.drop_ruby[0] }}"
@@ -125,7 +125,7 @@
   ignore_errors: yes
 
 - name: check if user ruby version is {{ rbenv.default_ruby }}
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
+  shell: bash -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   become: yes
   become_user: "{{ item }}"
   with_items: "{{ rbenv_users }}"
@@ -136,7 +136,7 @@
   check_mode: no
 
 - name: set ruby {{ rbenv.default_ruby }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
+  shell: bash -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:


### PR DESCRIPTION
In addition to unifying Ansible "shell" command usage to bash throughout the source base, this fixes the problem where $SHELL is not properly defined when building Docker images resulting in a failed playbook application.