### PR TITLE
meta: bump minimum version to 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: rbenv
   company: Undev
   license: MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   version: 0.2
 
   platforms:


### PR DESCRIPTION
Required for `import_tasks`: https://docs.ansible.com/ansible/2.4/import_tasks_module.html