### PR TITLE
Fix 2.11 deprecation warnings

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -7,20 +7,16 @@
 
 - name: install build depends
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ rbenv_apt_packages }}"
     state: present
     install_recommends: no
-  with_items:
-    - "{{ rbenv_apt_packages }}"
   become: true
 
 - name: install extra build depends
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ rbenv_extra_depends }}"
     state: present
     install_recommends: no
-  with_items:
-    - "{{ rbenv_extra_depends }}"
   become: true
 
 - name: Create the list of ruby versions.
@@ -31,10 +27,9 @@
 
 - name: Install packages required to build Ruby 1.8.7
   apt:
-    name: "{{ item }}"
+    name:
+      - bison
+      - autoconf
+      - subversion
     state: present
-  with_items:
-    - bison
-    - autoconf
-    - subversion
   when: "'1.8.7' in rbenv_ruby_versions"

--- a/tasks/dnf_build_depends.yml
+++ b/tasks/dnf_build_depends.yml
@@ -1,16 +1,12 @@
 ---
 - name: install build depends
   dnf:
-    name: "{{ item }}"
+    name: "{{ rbenv_dnf_packages }}"
     state: present
-  with_items:
-    - "{{ rbenv_dnf_packages }}"
   become: true
 
 - name: install build depends
   dnf:
-    name: "{{ item }}"
+    name: "{{ rbenv_extra_depends }}"
     state: present
-  with_items:
-    - "{{ rbenv_extra_depends }}"
   become: true

--- a/tasks/homebrew_build_depends.yml
+++ b/tasks/homebrew_build_depends.yml
@@ -1,11 +1,10 @@
 ---
 - name: Install dependencies with homebrew
   homebrew:
-    name: "{{ item }}"
+    name:
+      - openssl
+      - libyaml
     state: present
-  with_items:
-    - openssl
-    - libyaml
 
 # required for building Ruby <= 1.9.3-p0
 - name: Install homebrew/dupes for ruby <= 1.9.3 with homebrew_tap

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -1,16 +1,12 @@
 ---
 - name: install build depends
   yum:
-    name: '{{ item }}'
+    name: '{{ rbenv_yum_packages }}'
     state: present
-  with_items:
-  - "{{ rbenv_yum_packages }}"
   become: true
 
 - name: install extra build depends
   yum:
-    name: '{{ item }}'
+    name: '{{ rbenv_extra_depends }}'
     state: present
-  with_items:
-  - "{{ rbenv_extra_depends }}"
   become: true


### PR DESCRIPTION
Correct syntax for squash_actions deprecation warnings:

> [DEPRECATION WARNING]: Invoking "homebrew" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['openssl', 'libyaml']` and remove the loop. This feature will be removed in version 2.11.