### PR TITLE
Deprecation warnings on bare variable interpretation

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -89,7 +89,7 @@
     - "{{ rbenv_versions.results }}"
     - "{{ rbenv.rubies|map(attribute='version')|list }}"
   when:
-    - rbenv_clean_up
+    - rbenv_clean_up | bool
     - item[0].stdout_lines|list != item[1]
   register: removable_rubies
   ignore_errors: yes
@@ -98,7 +98,7 @@
   shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
   changed_when: false
   become: yes
-  when: rbenv_clean_up
+  when: rbenv_clean_up | bool
   ignore_errors: yes
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -128,7 +128,7 @@
     - "{{ rbenv_users }}"
     - "{{ rbenv.rubies|map(attribute='version')|list }}"
   when:
-    - rbenv_clean_up
+    - rbenv_clean_up | bool
     - item[0].item[0] == item[1]
     - item[0].stdout_lines|list != item[2]
   register: removable_rubies
@@ -140,7 +140,7 @@
   become: yes
   become_user: "{{ item.ansible_facts.drop_ruby[0] }}"
   with_items: "{{ removable_rubies.results }}"
-  when: rbenv_clean_up
+  when: rbenv_clean_up | bool
   ignore_errors: yes
 
 - name: check if user ruby version is {{ rbenv.default_ruby }}


### PR DESCRIPTION
2.12 changes bare variable interpretation in conditionals. Ensure rbenv_clean_up is always treated as bool. Part of https://github.com/ansible/ansible/issues/53428