### PR TITLE
Remove dependency on bash

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -111,6 +111,6 @@
 
 - name: set ruby {{ rbenv.default_ruby }} for system
   become: yes
-  shell: bash -lc "rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
+  shell: $SHELL -lc "rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
   when:
     - ruby_selected.rc != 0


### PR DESCRIPTION
This is the only tasks explicitly using bash rather than $SHELL. With this out of the way bash is not needed and any other shell can do the job properly.