### PR TITLE
Fix sh

### DIFF
--- a/tasks/system_install.yml
+++ b/tasks/system_install.yml
@@ -66,7 +66,7 @@
   changed_when: '"changed from" in rbenv_chmod.stdout'
 
 - name: check ruby versions installed for system
-  shell: $SHELL -lc "rbenv versions --bare"
+  shell: $0 -lc "rbenv versions --bare"
   register: rbenv_versions
   with_items: '{{ rbenv.rubies }}'
   changed_when: false
@@ -75,7 +75,7 @@
   check_mode: no
 
 - name: install ruby versions for system
-  shell: $SHELL -lc "rbenv install --skip-existing {{ item.version }}"
+  shell: $0 -lc "rbenv install --skip-existing {{ item.version }}"
   become: yes
   with_items:
     - '{{ rbenv.rubies }}'
@@ -95,14 +95,14 @@
   ignore_errors: yes
 
 - name: remove old rubies
-  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
+  shell: $0 -lc "rm -rf {{ rbenv_root }}/versions/{{ ansible_facts.drop_ruby }}"
   changed_when: false
   become: yes
   when: rbenv_clean_up | bool
   ignore_errors: yes
 
 - name: check if current system ruby version is {{ rbenv.default_ruby }}
-  shell: $SHELL -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
+  shell: $0 -lc "rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   register: ruby_selected
   changed_when: false
   ignore_errors: yes
@@ -111,6 +111,6 @@
 
 - name: set ruby {{ rbenv.default_ruby }} for system
   become: yes
-  shell: $SHELL -lc "rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
+  shell: $0 -lc "rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
   when:
     - ruby_selected.rc != 0

--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -89,7 +89,7 @@
     - rbenv_set_vars | bool
 
 - name: check ruby versions installed for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
+  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv versions --bare"
   with_items: "{{ rbenv_users }}"
   become: yes
   become_user: "{{ item }}"
@@ -99,7 +99,7 @@
   check_mode: no
 
 - name: install ruby {{ item[1].version }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv install --skip-existing {{ item[1].version }}"
+  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv install --skip-existing {{ item[1].version }}"
   become: yes
   args:
     creates: "~/.rbenv/versions/{{ item[1].version }}"
@@ -127,7 +127,7 @@
   register: removable_rubies
 
 - name: remove old rubies
-  shell: $SHELL -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
+  shell: $0 -lc "rm -rf {{ rbenv_root }}/versions/{{ item.ansible_facts.drop_ruby[1] }}"
   changed_when: false
   become: yes
   become_user: "{{ item.ansible_facts.drop_ruby[0] }}"
@@ -135,7 +135,7 @@
   when: rbenv_clean_up | bool
 
 - name: check if user ruby version is {{ rbenv.default_ruby }}
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
+  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ rbenv.default_ruby }}'"
   become: yes
   become_user: "{{ item }}"
   with_items: "{{ rbenv_users }}"
@@ -145,7 +145,7 @@
   check_mode: no
 
 - name: set ruby {{ rbenv.default_ruby }} for select users
-  shell: $SHELL -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
+  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:


### PR DESCRIPTION
If you are running sh shell $SHELL variable isn't populated and tasks fail with:
"stderr": "/bin/sh: 1: -lc: not found", "stderr_lines": ["/bin/sh: 1: -lc: not found"],

Both bash and sh support reading the filename of running script from $0 and in interactive shell it's current shell name.